### PR TITLE
change key mapping for mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Firefox 57+ extension that provides nine easy keyboard shortcuts to open new tab
 ## Usage
 By default the extension registers the following shortcuts: `Ctrl + Shift + #`, where `#` stands for numbers between 1 and 9. To open a new tab without a container simply use the default Firefox shortcut for that (`Ctrl + T`).
 
-Note for Mac/OS X users: use the `Command` key instead of `Ctrl`.
+Note for Mac/OS X users: use ⌥ + ⇧ + `#`.
 
 When one of those shortcuts is pressed, a new tab will be opened using the container whose number is represented by the shortcut, following the order displayed in Firefox's "containers" menu E.g. `Ctrl + Shift + 1` will open the first container in that list.
 

--- a/manifest.json
+++ b/manifest.json
@@ -22,55 +22,64 @@
   "commands": {
     "ecs-new-tab-container-1": {
       "suggested_key": {
-        "default": "Ctrl+Shift+1"
+        "default": "Ctrl+Shift+1",
+        "mac": "Alt+Shift+1"
       },
       "description": "Open a tab on the first non-default container"
     },
     "ecs-new-tab-container-2": {
       "suggested_key": {
-        "default": "Ctrl+Shift+2"
+        "default": "Ctrl+Shift+2",
+        "mac": "Alt+Shift+2"
       },
       "description": "Open a tab on the second non-default container"
     },
     "ecs-new-tab-container-3": {
       "suggested_key": {
-        "default": "Ctrl+Shift+3"
+        "default": "Ctrl+Shift+3",
+        "mac": "Alt+Shift+3"
       },
       "description": "Open a tab on the third non-default container"
     },
     "ecs-new-tab-container-4": {
       "suggested_key": {
-        "default": "Ctrl+Shift+4"
+        "default": "Ctrl+Shift+4",
+        "mac": "Alt+Shift+4"
       },
       "description": "Open a tab on the fourth non-default container"
     },
     "ecs-new-tab-container-5": {
       "suggested_key": {
-        "default": "Ctrl+Shift+5"
+        "default": "Ctrl+Shift+5",
+        "mac": "Alt+Shift+5"
       },
       "description": "Open a tab on the fifth non-default container"
     },
     "ecs-new-tab-container-6": {
       "suggested_key": {
-        "default": "Ctrl+Shift+6"
+        "default": "Ctrl+Shift+6",
+        "mac": "Alt+Shift+6"
       },
       "description": "Open a tab on the sixth non-default container"
     },
     "ecs-new-tab-container-7": {
       "suggested_key": {
-        "default": "Ctrl+Shift+7"
+        "default": "Ctrl+Shift+7",
+        "mac": "Alt+Shift+7"
       },
       "description": "Open a tab on the seventh non-default container"
     },
     "ecs-new-tab-container-8": {
       "suggested_key": {
-        "default": "Ctrl+Shift+8"
+        "default": "Ctrl+Shift+8",
+        "mac": "Alt+Shift+8"
       },
       "description": "Open a tab on the eighth non-default container"
     },
     "ecs-new-tab-container-9": {
       "suggested_key": {
-        "default": "Ctrl+Shift+9"
+        "default": "Ctrl+Shift+9",
+        "mac": "Alt+Shift+9"
       },
       "description": "Open a tab on the nineth non-default container"
     }


### PR DESCRIPTION
From MDN: 
> modifier (mandatory, except for function keys). This can be any of: "Ctrl", "Alt", "Command", "MacCtrl".
secondary modifier (optional). If supplied, this must be "Shift".

Thus we have either `MacCtrl` or `Alt` keys. I'd go for Alt :)