### PR TITLE
Change the new-tab shortcut to Ctrl(Cmd on Mac)+Alt+T

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
   "commands": {
     "ecs-new-tab-current-container": {
       "suggested_key": {
-        "default": "Alt+T"
+        "default": "Ctrl+Alt+T"
       },
       "description": "Open a new tab on the current container"
     },


### PR DESCRIPTION
Fixes #5