### PR TITLE
Implement reopen current tab in container shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 Firefox 57+ extension that provides nine easy keyboard shortcuts to open new tabs on different containers.
 
 ## Usage
+#### Current Tab on Specified Container
+Use `Ctrl (Cmd on Mac) + Alt + #` to reopen the current tab in the specified container, where `#` stands for numbers between 1 and 9. This closes the current tab and replaces its position with a new tab at the same URL in the specified container.
+
 #### New Tab on Current Container
 Use `Ctrl (Cmd on Mac) + Alt + T` to open a new tab in the current window, using the current container.
 

--- a/manifest.json
+++ b/manifest.json
@@ -87,7 +87,7 @@
         "default": "Ctrl+Shift+9",
         "mac": "Alt+Shift+9"
       },
-      "description": "Open a tab on the nineth non-default container"
+      "description": "Open a tab on the ninth non-default container"
     },
     "ecs-current-tab-container-1": {
       "suggested_key": {
@@ -141,7 +141,7 @@
       "suggested_key": {
         "default": "Ctrl+Alt+9"
       },
-      "description": "Reopen the current tab on the nineth non-default container"
+      "description": "Reopen the current tab on the ninth non-default container"
     }
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -88,6 +88,60 @@
         "mac": "Alt+Shift+9"
       },
       "description": "Open a tab on the nineth non-default container"
+    },
+    "ecs-current-tab-container-1": {
+      "suggested_key": {
+        "default": "Ctrl+Alt+1"
+      },
+      "description": "Reopen the current tab on the first non-default container"
+    },
+    "ecs-current-tab-container-2": {
+      "suggested_key": {
+        "default": "Ctrl+Alt+2"
+      },
+      "description": "Reopen the current tab on the second non-default container"
+    },
+    "ecs-current-tab-container-3": {
+      "suggested_key": {
+        "default": "Ctrl+Alt+3"
+      },
+      "description": "Reopen the current tab on the third non-default container"
+    },
+    "ecs-current-tab-container-4": {
+      "suggested_key": {
+        "default": "Ctrl+Alt+4"
+      },
+      "description": "Reopen the current tab on the fourth non-default container"
+    },
+    "ecs-current-tab-container-5": {
+      "suggested_key": {
+        "default": "Ctrl+Alt+5"
+      },
+      "description": "Reopen the current tab on the fifth non-default container"
+    },
+    "ecs-current-tab-container-6": {
+      "suggested_key": {
+        "default": "Ctrl+Alt+6"
+      },
+      "description": "Reopen the current tab on the sixth non-default container"
+    },
+    "ecs-current-tab-container-7": {
+      "suggested_key": {
+        "default": "Ctrl+Alt+7"
+      },
+      "description": "Reopen the current tab on the seventh non-default container"
+    },
+    "ecs-current-tab-container-8": {
+      "suggested_key": {
+        "default": "Ctrl+Alt+8"
+      },
+      "description": "Reopen the current tab on the eighth non-default container"
+    },
+    "ecs-current-tab-container-9": {
+      "suggested_key": {
+        "default": "Ctrl+Alt+9"
+      },
+      "description": "Reopen the current tab on the nineth non-default container"
     }
   }
 }


### PR DESCRIPTION
- Fixes #8 
- Opens immediately after the current tab
- Closes the current tab
- Uses `Ctrl/Cmd + Alt + #` shortcuts
- Confirmed working on both Ubuntu and MacOS