### PR TITLE
fix: prevent losing tab url when switching containers

### DIFF
--- a/background.js
+++ b/background.js
@@ -73,14 +73,21 @@ async function openTabInContainer(contextNumber) {
     return;
   }
 
-  browser.tabs.query({currentWindow:true, active:true}).then(function(results) {
+  browser.tabs.query({currentWindow:true, active:true, status:'complete'}).then(function(results) {
     if (!results || results.length < 1) {
       return; // do nothing
     }
+
     let currentTab = results[0];
+
+    if (currentTab.url.startsWith('about')) {
+      return;
+    }
+
     browser.tabs.create({
       cookieStoreId: context.cookieStoreId,
       index: currentTab.index + 1,
+      discarded: true,
       url: currentTab.url
     });
     browser.tabs.remove(currentTab.id);


### PR DESCRIPTION
This PR helps to mitigate an issue presented when quickly switching between containers for the current tab, where that tab would lose its yet unresolved URL and the add-on would open a new empty tab in its place.

A few things to comment in regard to the changes that follow:

```diff
-  browser.tabs.query({currentWindow:true, active:true}).then(function(results) {
+  browser.tabs.query({currentWindow:true, active:true, status:'complete'}).then(function(results) {
```

We are now using the `status` query filter to only allow switching container for resolved (`completed`) tabs.
This will prevent creating a duplication for a tab which was still loading.

```diff
+    if (currentTab.url.startsWith('about')) {
+      return;
+    }
```

Sometimes, when creating a new tab the URL could be missing as per my tests and tabs start to open with the `about:blank` URL, so we are preventing this here as well.

```diff
     browser.tabs.create({
       cookieStoreId: context.cookieStoreId,
       index: currentTab.index + 1,
+      discarded: true,
       url: currentTab.url
     });
```

And finally, we are adding creating a tab as `discarded` in order to speed up the process and free up some memory until the tab is not displayed. By creating a tab as `discarded` I could perceive some performance improvements, although, nothing really benchmarked.

Resolves #21 