### PR TITLE
Keep tab active when reloading in container

### DIFF
--- a/background.js
+++ b/background.js
@@ -87,7 +87,6 @@ async function openTabInContainer(contextNumber) {
     browser.tabs.create({
       cookieStoreId: context.cookieStoreId,
       index: currentTab.index + 1,
-      discarded: true,
       url: currentTab.url
     });
     browser.tabs.remove(currentTab.id);


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/1759192/136963683-2d1b2e60-7d1f-4c77-9a18-3b8fed2b2dd5.mov

After:

https://user-images.githubusercontent.com/1759192/136963701-8ba804d1-4da3-4305-a6f5-ef9a32cfc555.mov



Currently when one uses a shortcut to reload the current tab in a different container, it will loose it's active status. I.e. instead of reloading the current tab and keeping it active, it will change the active tab to a previous tab (see "before" vid).

This is caused by the `discarded: true` flag, which forces the reloaded tab to be loaded in discarded state (and thus inactive state).

By removing this flag it'll now reload the tab in the new container and keep this tab as the active tab. (see "after" vid)