### PR TITLE
Add permissions to greetings workflow

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -5,6 +5,9 @@ on: [pull_request, issues]
 jobs:
   greeting:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
     - uses: actions/first-interaction@v1
       with:


### PR DESCRIPTION
Potential fix for [https://github.com/gsomoza/firefox-easy-container-shortcuts/security/code-scanning/1](https://github.com/gsomoza/firefox-easy-container-shortcuts/security/code-scanning/1)

In general, to fix this class of problem you add a `permissions` block either at the top (root) of the workflow or inside each job to explicitly restrict the `GITHUB_TOKEN` to the least privileges required. For a greeting/first-interaction workflow that posts a message on first issues and PRs, the token needs to be able to write to issues and pull requests, and it is safe to keep other scopes at read-only or omit them entirely.

For this specific workflow, the simplest and least-disruptive fix is to add a `permissions` block under the `greeting` job, since CodeQL points to that job and we only see one job in the snippet. We should give it only `issues: write` and `pull-requests: write`, which are the minimal permissions necessary for `actions/first-interaction@v1` to post the configured `issue-message` and `pr-message`. No other functionality in the provided snippet requires broader permissions (such as `contents: write`). Concretely, in `.github/workflows/greetings.yml`, under `jobs:`, inside the `greeting:` job and at the same indentation level as `runs-on:`, insert:

```yaml
    permissions:
      issues: write
      pull-requests: write
```

This keeps existing behavior (the workflow can still comment on issues and PRs) while constraining the token to only those operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
